### PR TITLE
Go: write-tree format fixed

### DIFF
--- a/solutions/go/05-write_tree/code/cmd/mygit/write_tree_command.go
+++ b/solutions/go/05-write_tree/code/cmd/mygit/write_tree_command.go
@@ -74,7 +74,7 @@ func writeTree(dir string) (object.Hash, error) {
 			}
 		}
 
-		table = fmt.Appendf(table, "%06o %v\000%s", gitMode, f.Name(), hash[:])
+		table = fmt.Appendf(table, "%o %v\000%s", gitMode, f.Name(), hash[:])
 	}
 
 	hash, err := object.Store(bytes.NewReader(table), "tree", int64(len(table)))

--- a/solutions/go/05-write_tree/diff/cmd/mygit/write_tree_command.go.diff
+++ b/solutions/go/05-write_tree/diff/cmd/mygit/write_tree_command.go.diff
@@ -75,7 +75,7 @@
 +			}
 +		}
 +
-+		table = fmt.Appendf(table, "%06o %v\000%s", gitMode, f.Name(), hash[:])
++		table = fmt.Appendf(table, "%o %v\000%s", gitMode, f.Name(), hash[:])
 +	}
 +
 +	hash, err := object.Store(bytes.NewReader(table), "tree", int64(len(table)))

--- a/solutions/go/06-create_commit/code/cmd/mygit/write_tree_command.go
+++ b/solutions/go/06-create_commit/code/cmd/mygit/write_tree_command.go
@@ -74,7 +74,7 @@ func writeTree(dir string) (object.Hash, error) {
 			}
 		}
 
-		table = fmt.Appendf(table, "%06o %v\000%s", gitMode, f.Name(), hash[:])
+		table = fmt.Appendf(table, "%o %v\000%s", gitMode, f.Name(), hash[:])
 	}
 
 	hash, err := object.Store(bytes.NewReader(table), "tree", int64(len(table)))


### PR DESCRIPTION
Changed tree blob format to match git's encoding and hash.