### PR TITLE
make `your_git` locally testable with java

### DIFF
--- a/compiled_starters/java/your_git.sh
+++ b/compiled_starters/java/your_git.sh
@@ -6,5 +6,6 @@
 #
 # DON'T EDIT THIS!
 set -e
-mvn -B --quiet package -Ddir=/tmp/codecrafters-git-target
+BASEDIR=$(dirname "$0")
+mvn -B --quiet package -Ddir=/tmp/codecrafters-git-target -f "$BASEDIR/pom.xml"
 exec java -jar /tmp/codecrafters-git-target/java_git.jar "$@"

--- a/solutions/java/01-init/code/your_git.sh
+++ b/solutions/java/01-init/code/your_git.sh
@@ -6,5 +6,6 @@
 #
 # DON'T EDIT THIS!
 set -e
-mvn -B --quiet package -Ddir=/tmp/codecrafters-git-target
+BASEDIR=$(dirname "$0")
+mvn -B --quiet package -Ddir=/tmp/codecrafters-git-target -f "$BASEDIR/pom.xml"
 exec java -jar /tmp/codecrafters-git-target/java_git.jar "$@"

--- a/starter_templates/java/your_git.sh
+++ b/starter_templates/java/your_git.sh
@@ -6,5 +6,6 @@
 #
 # DON'T EDIT THIS!
 set -e
-mvn -B --quiet package -Ddir=/tmp/codecrafters-git-target
+BASEDIR=$(dirname "$0")
+mvn -B --quiet package -Ddir=/tmp/codecrafters-git-target -f "$BASEDIR/pom.xml"
 exec java -jar /tmp/codecrafters-git-target/java_git.jar "$@"


### PR DESCRIPTION
when testing locally the challenge instructs devs to create a temp-dir and call `your_git.sh` from there.

`your_git.sh` script in java does not really work when you are in a different folder because it looks for the pom.xml file in the same directory.

this PR fixes that and makes sure it finds the `pom.xml`.