### PR TITLE
Add alpha tester to git-zig

### DIFF
--- a/compiled_starters/zig/.gitignore
+++ b/compiled_starters/zig/.gitignore
@@ -1,5 +1,6 @@
 # Zig build artifacts
 zig-cache/
+.zig-cache/
 zig-out/
 
 # Compiled binary output

--- a/course-definition.yml
+++ b/course-definition.yml
@@ -44,7 +44,8 @@ languages:
   - slug: "typescript"
     release_status: "beta"
   - slug: "zig"
-    release_status: "beta"
+    release_status: "alpha"
+    alpha_tester_usernames: ["typesafe"]
 
 # TODO: Add this back once builds are faster
 #  kotlin: https://github.com/codecrafters-io/git-starter-kotlin

--- a/solutions/zig/01-gg4/code/.gitignore
+++ b/solutions/zig/01-gg4/code/.gitignore
@@ -1,5 +1,6 @@
 # Zig build artifacts
 zig-cache/
+.zig-cache/
 zig-out/
 
 # Compiled binary output

--- a/starter_templates/zig/.gitignore
+++ b/starter_templates/zig/.gitignore
@@ -1,5 +1,6 @@
 # Zig build artifacts
 zig-cache/
+.zig-cache/
 zig-out/
 
 # Compiled binary output


### PR DESCRIPTION
This pull request primarily focuses on updates to the Zig language environment and its status in the `course-definition.yml` file. The changes include the addition of `.zig-cache/` to the `.gitignore` files in various directories and the modification of the release status of the Zig language from "beta" to "alpha". A tester username is also added for the alpha testing phase.

Updates to Zig environment:

* [`compiled_starters/zig/.gitignore`](diffhunk://#diff-41b1ba88488e07a83adb20b73e4625c100a5886f47efab6155f43a0b3fc4f971R3): Added `.zig-cache/` to the list of ignored files and directories. This is likely to prevent Zig build cache files from being tracked by Git.
* [`solutions/zig/01-gg4/code/.gitignore`](diffhunk://#diff-41b1ba88488e07a83adb20b73e4625c100a5886f47efab6155f43a0b3fc4f971R3): Similar to the above, `.zig-cache/` was added to the list of ignored files and directories.
* [`starter_templates/zig/.gitignore`](diffhunk://#diff-41b1ba88488e07a83adb20b73e4625c100a5886f47efab6155f43a0b3fc4f971R3): Again, `.zig-cache/` was added to the list of ignored files and directories.

Update to course definition:

* [`course-definition.yml`](diffhunk://#diff-c67feeec2dcea8ec9f038ebeeb9f352f3af256cd9196a85d642e305f9f3a45dcL47-R48): The release status of the Zig language was changed from "beta" to "alpha". Additionally, a list of alpha tester usernames was added, with "typesafe" being the only entry at this time. This suggests that the Zig language is entering a new phase of testing.