### PR TITLE
[Git] CC-1656 Upgrade Zig to 0.14

### DIFF
--- a/compiled_starters/zig/.codecrafters/run.sh
+++ b/compiled_starters/zig/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec $(dirname $0)/zig-out/bin/zit "$@"
+exec $(dirname $0)/zig-out/bin/main "$@"

--- a/compiled_starters/zig/.gitignore
+++ b/compiled_starters/zig/.gitignore
@@ -1,10 +1,10 @@
 # Zig build artifacts
+main
 zig-cache/
 .zig-cache/
 zig-out/
 
 # Compiled binary output
-main
 bin/
 !bin/.gitkeep
 
@@ -13,6 +13,6 @@ bin/
 *.h
 
 # Ignore OS and editor specific files
-.DS_Store
+**/.DS_Store
 *.swp
 *~

--- a/compiled_starters/zig/README.md
+++ b/compiled_starters/zig/README.md
@@ -27,7 +27,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `zig (0.12)` installed locally
+1. Ensure you have `zig (0.14)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `src/main.zig`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/compiled_starters/zig/build.zig
+++ b/compiled_starters/zig/build.zig
@@ -3,12 +3,7 @@ const std = @import("std");
 // Learn more about this file here: https://ziglang.org/learn/build-system
 pub fn build(b: *std.Build) void {
     const exe = b.addExecutable(.{
-
-        // DON'T EDIT THIS!
-        // CodeCrafters uses this filename to test your code. Don't make any changes here!
-        .name = "zit",
-        // DON'T EDIT THIS!
-
+        .name = "main",
         .root_source_file = b.path("src/main.zig"),
         .target = b.standardTargetOptions(.{}),
         .optimize = b.standardOptimizeOption(.{}),
@@ -24,13 +19,15 @@ pub fn build(b: *std.Build) void {
     // such a dependency.
     const run_cmd = b.addRunArtifact(exe);
 
-    if (b.args) |args| {
-        run_cmd.addArgs(args);
-    }
-
     // This creates a build step. It will be visible in the `zig build --help` menu,
     // and can be selected like this: `zig build run`
     // This will evaluate the `run` step rather than the default, which is "install".
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
+
+    // This allows the user to pass arguments to the application in the build
+    // command itself, like this: `zig build run -- arg1 arg2 etc`
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
 }

--- a/compiled_starters/zig/build.zig.zon
+++ b/compiled_starters/zig/build.zig.zon
@@ -1,5 +1,7 @@
 .{
-    .name = "zig",
+    .name = .codecrafters_git,
+    .fingerprint = 0xb05a32ec81f448fe,
+
     // This is a [Semantic Version](https://semver.org/).
     // In a future version of Zig it will be used for package deduplication.
     .version = "0.0.0",
@@ -7,7 +9,7 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    //.minimum_zig_version = "0.12.0",
+    .minimum_zig_version = "0.14.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/compiled_starters/zig/codecrafters.yml
+++ b/compiled_starters/zig/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Zig version used to run your code
 # on Codecrafters.
 #
-# Available versions: zig-0.12
-language_pack: zig-0.12
+# Available versions: zig-0.14
+language_pack: zig-0.14

--- a/compiled_starters/zig/your_program.sh
+++ b/compiled_starters/zig/your_program.sh
@@ -21,4 +21,4 @@ set -e # Exit early if any commands fail
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec $(dirname $0)/zig-out/bin/zit "$@"
+exec $(dirname $0)/zig-out/bin/main "$@"

--- a/dockerfiles/zig-0.14.Dockerfile
+++ b/dockerfiles/zig-0.14.Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM alpine:3.20
+
+RUN apk add --no-cache 'xz>=5.6' 'curl>=8.9'
+
+# Download and install Zig
+RUN curl -O https://ziglang.org/download/0.14.0/zig-linux-x86_64-0.14.0.tar.xz \
+    && tar -xf zig-linux-x86_64-0.14.0.tar.xz \
+    && mv zig-linux-x86_64-0.14.0 /usr/local/zig \
+    && rm zig-linux-x86_64-0.14.0.tar.xz
+
+# Add Zig to PATH
+ENV PATH="/usr/local/zig:${PATH}"
+
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="build.zig,build.zig.zon"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# This runs zig build
+RUN .codecrafters/compile.sh
+
+# Cache build directory
+RUN mkdir -p /app-cached
+RUN mv /app/.zig-cache /app-cached/.zig-cache || true

--- a/solutions/zig/01-gg4/code/.codecrafters/run.sh
+++ b/solutions/zig/01-gg4/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec $(dirname $0)/zig-out/bin/zit "$@"
+exec $(dirname $0)/zig-out/bin/main "$@"

--- a/solutions/zig/01-gg4/code/.gitignore
+++ b/solutions/zig/01-gg4/code/.gitignore
@@ -1,10 +1,10 @@
 # Zig build artifacts
+main
 zig-cache/
 .zig-cache/
 zig-out/
 
 # Compiled binary output
-main
 bin/
 !bin/.gitkeep
 
@@ -13,6 +13,6 @@ bin/
 *.h
 
 # Ignore OS and editor specific files
-.DS_Store
+**/.DS_Store
 *.swp
 *~

--- a/solutions/zig/01-gg4/code/README.md
+++ b/solutions/zig/01-gg4/code/README.md
@@ -27,7 +27,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `zig (0.12)` installed locally
+1. Ensure you have `zig (0.14)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `src/main.zig`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/zig/01-gg4/code/build.zig
+++ b/solutions/zig/01-gg4/code/build.zig
@@ -3,12 +3,7 @@ const std = @import("std");
 // Learn more about this file here: https://ziglang.org/learn/build-system
 pub fn build(b: *std.Build) void {
     const exe = b.addExecutable(.{
-
-        // DON'T EDIT THIS!
-        // CodeCrafters uses this filename to test your code. Don't make any changes here!
-        .name = "zit",
-        // DON'T EDIT THIS!
-
+        .name = "main",
         .root_source_file = b.path("src/main.zig"),
         .target = b.standardTargetOptions(.{}),
         .optimize = b.standardOptimizeOption(.{}),
@@ -24,13 +19,15 @@ pub fn build(b: *std.Build) void {
     // such a dependency.
     const run_cmd = b.addRunArtifact(exe);
 
-    if (b.args) |args| {
-        run_cmd.addArgs(args);
-    }
-
     // This creates a build step. It will be visible in the `zig build --help` menu,
     // and can be selected like this: `zig build run`
     // This will evaluate the `run` step rather than the default, which is "install".
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
+
+    // This allows the user to pass arguments to the application in the build
+    // command itself, like this: `zig build run -- arg1 arg2 etc`
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
 }

--- a/solutions/zig/01-gg4/code/build.zig.zon
+++ b/solutions/zig/01-gg4/code/build.zig.zon
@@ -1,5 +1,7 @@
 .{
-    .name = "zig",
+    .name = .codecrafters_git,
+    .fingerprint = 0xb05a32ec81f448fe,
+
     // This is a [Semantic Version](https://semver.org/).
     // In a future version of Zig it will be used for package deduplication.
     .version = "0.0.0",
@@ -7,7 +9,7 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    //.minimum_zig_version = "0.12.0",
+    .minimum_zig_version = "0.14.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/solutions/zig/01-gg4/code/codecrafters.yml
+++ b/solutions/zig/01-gg4/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Zig version used to run your code
 # on Codecrafters.
 #
-# Available versions: zig-0.12
-language_pack: zig-0.12
+# Available versions: zig-0.14
+language_pack: zig-0.14

--- a/solutions/zig/01-gg4/code/your_program.sh
+++ b/solutions/zig/01-gg4/code/your_program.sh
@@ -21,4 +21,4 @@ set -e # Exit early if any commands fail
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec $(dirname $0)/zig-out/bin/zit "$@"
+exec $(dirname $0)/zig-out/bin/main "$@"

--- a/starter_templates/zig/code/.codecrafters/run.sh
+++ b/starter_templates/zig/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec $(dirname $0)/zig-out/bin/zit "$@"
+exec $(dirname $0)/zig-out/bin/main "$@"

--- a/starter_templates/zig/code/.gitignore
+++ b/starter_templates/zig/code/.gitignore
@@ -1,10 +1,10 @@
 # Zig build artifacts
+main
 zig-cache/
 .zig-cache/
 zig-out/
 
 # Compiled binary output
-main
 bin/
 !bin/.gitkeep
 
@@ -13,6 +13,6 @@ bin/
 *.h
 
 # Ignore OS and editor specific files
-.DS_Store
+**/.DS_Store
 *.swp
 *~

--- a/starter_templates/zig/code/build.zig
+++ b/starter_templates/zig/code/build.zig
@@ -3,12 +3,7 @@ const std = @import("std");
 // Learn more about this file here: https://ziglang.org/learn/build-system
 pub fn build(b: *std.Build) void {
     const exe = b.addExecutable(.{
-
-        // DON'T EDIT THIS!
-        // CodeCrafters uses this filename to test your code. Don't make any changes here!
-        .name = "zit",
-        // DON'T EDIT THIS!
-
+        .name = "main",
         .root_source_file = b.path("src/main.zig"),
         .target = b.standardTargetOptions(.{}),
         .optimize = b.standardOptimizeOption(.{}),
@@ -24,13 +19,15 @@ pub fn build(b: *std.Build) void {
     // such a dependency.
     const run_cmd = b.addRunArtifact(exe);
 
-    if (b.args) |args| {
-        run_cmd.addArgs(args);
-    }
-
     // This creates a build step. It will be visible in the `zig build --help` menu,
     // and can be selected like this: `zig build run`
     // This will evaluate the `run` step rather than the default, which is "install".
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
+
+    // This allows the user to pass arguments to the application in the build
+    // command itself, like this: `zig build run -- arg1 arg2 etc`
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
 }

--- a/starter_templates/zig/code/build.zig.zon
+++ b/starter_templates/zig/code/build.zig.zon
@@ -1,5 +1,7 @@
 .{
-    .name = "zig",
+    .name = .codecrafters_git,
+    .fingerprint = 0xb05a32ec81f448fe,
+
     // This is a [Semantic Version](https://semver.org/).
     // In a future version of Zig it will be used for package deduplication.
     .version = "0.0.0",
@@ -7,7 +9,7 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    //.minimum_zig_version = "0.12.0",
+    .minimum_zig_version = "0.14.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/starter_templates/zig/config.yml
+++ b/starter_templates/zig/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: zig (0.12)
+  required_executable: zig (0.14)
   user_editable_file: src/main.zig


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the primary executable name used in runtime and build processes for greater consistency.
- **Documentation**
  - Revised installation instructions and dependency notes to require Zig version 0.14.
- **Chores**
  - Refined ignore settings to better manage build artifacts and system-specific files.
  - Introduced a new Docker configuration to streamline the development environment with Zig 0.14.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->