### PR TITLE
Remove git executable from Dockerfiles

### DIFF
--- a/dockerfiles/go-1.24.Dockerfile
+++ b/dockerfiles/go-1.24.Dockerfile
@@ -15,4 +15,5 @@ RUN GODEBUG="installgoroot=all" go install std
 
 RUN go mod download
 
-RUN apk add --no-cache 'git>=2.40'
+# Remove git executable to prevent test solutions from using the git executable
+RUN apk del git

--- a/dockerfiles/python-3.13.Dockerfile
+++ b/dockerfiles/python-3.13.Dockerfile
@@ -1,3 +1,4 @@
 FROM python:3.13-alpine
 
-RUN apk add --no-cache 'git>=2.40'
+# Remove git executable to prevent test solutions from using the git executable
+RUN apk del git

--- a/dockerfiles/rust-1.85.Dockerfile
+++ b/dockerfiles/rust-1.85.Dockerfile
@@ -11,3 +11,6 @@ COPY --exclude=.git --exclude=README.md . /app
 
 # This runs cargo build
 RUN .codecrafters/compile.sh
+
+# Remove git executable to prevent test solutions from using the git executable
+RUN apt-get remove -y git


### PR DESCRIPTION
Eliminate the git executable from Dockerfiles to prevent test solutions from using it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the Git executable from Go, Python, and Rust environment images to restrict access to Git within containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->