### PR TITLE
Link OpenSSL and ZLIB for C and C++

### DIFF
--- a/compiled_starters/c/CMakeLists.txt
+++ b/compiled_starters/c/CMakeLists.txt
@@ -6,4 +6,10 @@ file(GLOB_RECURSE SOURCE_FILES src/*.c src/*.h)
 
 set(CMAKE_C_STANDARD 23) # Enable the C23 standard
 
+find_package(OpenSSL REQUIRED)
+find_package(ZLIB REQUIRED)
+
 add_executable(git ${SOURCE_FILES})
+
+target_link_libraries(git PRIVATE OpenSSL::Crypto)
+target_link_libraries(git PRIVATE ZLIB::ZLIB)

--- a/compiled_starters/cpp/CMakeLists.txt
+++ b/compiled_starters/cpp/CMakeLists.txt
@@ -6,6 +6,10 @@ set(CMAKE_CXX_STANDARD 23) # Enable the C++23 standard
 
 file(GLOB_RECURSE SOURCE_FILES src/*.cpp src/*.hpp)
 
+find_package(OpenSSL REQUIRED)
+find_package(ZLIB REQUIRED)
+
 add_executable(git ${SOURCE_FILES})
 
-target_link_libraries(git -lz)
+target_link_libraries(git PRIVATE OpenSSL::Crypto)
+target_link_libraries(git PRIVATE ZLIB::ZLIB)

--- a/solutions/c/01-gg4/code/CMakeLists.txt
+++ b/solutions/c/01-gg4/code/CMakeLists.txt
@@ -6,4 +6,10 @@ file(GLOB_RECURSE SOURCE_FILES src/*.c src/*.h)
 
 set(CMAKE_C_STANDARD 23) # Enable the C23 standard
 
+find_package(OpenSSL REQUIRED)
+find_package(ZLIB REQUIRED)
+
 add_executable(git ${SOURCE_FILES})
+
+target_link_libraries(git PRIVATE OpenSSL::Crypto)
+target_link_libraries(git PRIVATE ZLIB::ZLIB)

--- a/solutions/cpp/01-gg4/code/CMakeLists.txt
+++ b/solutions/cpp/01-gg4/code/CMakeLists.txt
@@ -6,6 +6,10 @@ set(CMAKE_CXX_STANDARD 23) # Enable the C++23 standard
 
 file(GLOB_RECURSE SOURCE_FILES src/*.cpp src/*.hpp)
 
+find_package(OpenSSL REQUIRED)
+find_package(ZLIB REQUIRED)
+
 add_executable(git ${SOURCE_FILES})
 
-target_link_libraries(git -lz)
+target_link_libraries(git PRIVATE OpenSSL::Crypto)
+target_link_libraries(git PRIVATE ZLIB::ZLIB)

--- a/starter_templates/c/code/CMakeLists.txt
+++ b/starter_templates/c/code/CMakeLists.txt
@@ -6,4 +6,10 @@ file(GLOB_RECURSE SOURCE_FILES src/*.c src/*.h)
 
 set(CMAKE_C_STANDARD 23) # Enable the C23 standard
 
+find_package(OpenSSL REQUIRED)
+find_package(ZLIB REQUIRED)
+
 add_executable(git ${SOURCE_FILES})
+
+target_link_libraries(git PRIVATE OpenSSL::Crypto)
+target_link_libraries(git PRIVATE ZLIB::ZLIB)

--- a/starter_templates/cpp/code/CMakeLists.txt
+++ b/starter_templates/cpp/code/CMakeLists.txt
@@ -6,6 +6,10 @@ set(CMAKE_CXX_STANDARD 23) # Enable the C++23 standard
 
 file(GLOB_RECURSE SOURCE_FILES src/*.cpp src/*.hpp)
 
+find_package(OpenSSL REQUIRED)
+find_package(ZLIB REQUIRED)
+
 add_executable(git ${SOURCE_FILES})
 
-target_link_libraries(git -lz)
+target_link_libraries(git PRIVATE OpenSSL::Crypto)
+target_link_libraries(git PRIVATE ZLIB::ZLIB)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated build configuration to require OpenSSL and Zlib libraries for C and C++ projects.
	- Improved dependency management by explicitly linking against OpenSSL and Zlib using modern CMake package references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->