### PR TITLE
Refactor stdout handling in Zig main files

### DIFF
--- a/compiled_starters/zig/src/main.zig
+++ b/compiled_starters/zig/src/main.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const stdout = std.fs.File.stdout();
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -8,20 +9,15 @@ pub fn main() !void {
     const args = try std.process.argsAlloc(allocator);
     defer std.process.argsFree(allocator, args);
 
-    var stdout_buffer: [1024]u8 = undefined;
-    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
-    const stdout = &stdout_writer.interface;
-
     if (args.len < 2) {
-        try stdout.print("Usage: {s} <command>\n", .{args[0]});
+        std.debug.print("Usage: {s} <command>\n", .{args[0]});
         return;
     }
 
     const command: []const u8 = args[1];
 
     // You can use print statements as follows for debugging, they'll be visible when running tests.
-    try stdout.print("Logs from your program will appear here!\n", .{});
-    try stdout.flush();
+    try stdout.writeAll("Logs from your program will appear here!\n");
 
     if (std.mem.eql(u8, command, "init")) {
         // Uncomment this block to pass the first stage
@@ -34,7 +30,6 @@ pub fn main() !void {
         //     defer head.close();
         //     _ = try head.write("ref: refs/heads/main\n");
         // }
-        // try stdout.print("Initialized git directory\n", .{});
-        // try stdout.flush();
+        // try stdout.writeAll("Initialized git directory\n");
     }
 }

--- a/compiled_starters/zig/src/main.zig
+++ b/compiled_starters/zig/src/main.zig
@@ -17,7 +17,7 @@ pub fn main() !void {
     const command: []const u8 = args[1];
 
     // You can use print statements as follows for debugging, they'll be visible when running tests.
-    try stdout.writeAll("Logs from your program will appear here!\n");
+    std.debug.print("Logs from your program will appear here!\n", .{});
 
     if (std.mem.eql(u8, command, "init")) {
         // Uncomment this block to pass the first stage

--- a/solutions/zig/01-gg4/code/src/main.zig
+++ b/solutions/zig/01-gg4/code/src/main.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const stdout = std.fs.File.stdout();
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -8,18 +9,12 @@ pub fn main() !void {
     const args = try std.process.argsAlloc(allocator);
     defer std.process.argsFree(allocator, args);
 
-    var stdout_buffer: [1024]u8 = undefined;
-    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
-    const stdout = &stdout_writer.interface;
-
     if (args.len < 2) {
-        try stdout.print("Usage: {s} <command>\n", .{args[0]});
+        std.debug.print("Usage: {s} <command>\n", .{args[0]});
         return;
     }
 
     const command: []const u8 = args[1];
-
-    try stdout.flush();
 
     if (std.mem.eql(u8, command, "init")) {
         const cwd = std.fs.cwd();
@@ -31,7 +26,6 @@ pub fn main() !void {
             defer head.close();
             _ = try head.write("ref: refs/heads/main\n");
         }
-        try stdout.print("Initialized git directory\n", .{});
-        try stdout.flush();
+        try stdout.writeAll("Initialized git directory\n");
     }
 }

--- a/solutions/zig/01-gg4/diff/src/main.zig.diff
+++ b/solutions/zig/01-gg4/diff/src/main.zig.diff
@@ -18,7 +18,7 @@
      const command: []const u8 = args[1];
 
 -    // You can use print statements as follows for debugging, they'll be visible when running tests.
--    try stdout.writeAll("Logs from your program will appear here!\n");
+-    std.debug.print("Logs from your program will appear here!\n", .{});
 -
      if (std.mem.eql(u8, command, "init")) {
 -        // Uncomment this block to pass the first stage

--- a/solutions/zig/01-gg4/diff/src/main.zig.diff
+++ b/solutions/zig/01-gg4/diff/src/main.zig.diff
@@ -1,5 +1,6 @@
-@@ -1,40 +1,37 @@
+@@ -1,35 +1,31 @@
  const std = @import("std");
+ const stdout = std.fs.File.stdout();
 
  pub fn main() !void {
      var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -9,21 +10,16 @@
      const args = try std.process.argsAlloc(allocator);
      defer std.process.argsFree(allocator, args);
 
-     var stdout_buffer: [1024]u8 = undefined;
-     var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
-     const stdout = &stdout_writer.interface;
-
      if (args.len < 2) {
-         try stdout.print("Usage: {s} <command>\n", .{args[0]});
+         std.debug.print("Usage: {s} <command>\n", .{args[0]});
          return;
      }
 
      const command: []const u8 = args[1];
 
 -    // You can use print statements as follows for debugging, they'll be visible when running tests.
--    try stdout.print("Logs from your program will appear here!\n", .{});
-     try stdout.flush();
-
+-    try stdout.writeAll("Logs from your program will appear here!\n");
+-
      if (std.mem.eql(u8, command, "init")) {
 -        // Uncomment this block to pass the first stage
 -        // const cwd = std.fs.cwd();
@@ -35,8 +31,7 @@
 -        //     defer head.close();
 -        //     _ = try head.write("ref: refs/heads/main\n");
 -        // }
--        // try stdout.print("Initialized git directory\n", .{});
--        // try stdout.flush();
+-        // try stdout.writeAll("Initialized git directory\n");
 +        const cwd = std.fs.cwd();
 +        _ = try cwd.makeDir("./.git");
 +        _ = try cwd.makeDir("./.git/objects");
@@ -46,7 +41,6 @@
 +            defer head.close();
 +            _ = try head.write("ref: refs/heads/main\n");
 +        }
-+        try stdout.print("Initialized git directory\n", .{});
-+        try stdout.flush();
++        try stdout.writeAll("Initialized git directory\n");
      }
  }

--- a/solutions/zig/01-gg4/explanation.md
+++ b/solutions/zig/01-gg4/explanation.md
@@ -13,8 +13,7 @@ _ = try cwd.makeDir("./.git/refs");
     defer head.close();
     _ = try head.write("ref: refs/heads/main\n");
 }
-try stdout.print("Initialized git directory\n", .{});
-try stdout.flush();
+try stdout.writeAll("Initialized git directory\n");
 ```
 
 Push your changes to pass the first stage:

--- a/starter_templates/zig/code/src/main.zig
+++ b/starter_templates/zig/code/src/main.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const stdout = std.fs.File.stdout();
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -8,20 +9,15 @@ pub fn main() !void {
     const args = try std.process.argsAlloc(allocator);
     defer std.process.argsFree(allocator, args);
 
-    var stdout_buffer: [1024]u8 = undefined;
-    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
-    const stdout = &stdout_writer.interface;
-
     if (args.len < 2) {
-        try stdout.print("Usage: {s} <command>\n", .{args[0]});
+        std.debug.print("Usage: {s} <command>\n", .{args[0]});
         return;
     }
 
     const command: []const u8 = args[1];
 
     // You can use print statements as follows for debugging, they'll be visible when running tests.
-    try stdout.print("Logs from your program will appear here!\n", .{});
-    try stdout.flush();
+    std.debug.print("Logs from your program will appear here!\n", .{});
 
     if (std.mem.eql(u8, command, "init")) {
         // Uncomment this block to pass the first stage
@@ -34,7 +30,6 @@ pub fn main() !void {
         //     defer head.close();
         //     _ = try head.write("ref: refs/heads/main\n");
         // }
-        // try stdout.print("Initialized git directory\n", .{});
-        // try stdout.flush();
+        // try stdout.writeAll("Initialized git directory\n");
     }
 }


### PR DESCRIPTION
- Replaced stdout.print with std.debug.print for usage messages in main.zig files.
- Updated stdout handling to use writeAll for logging messages.
- Removed unnecessary stdout buffer and writer setup for cleaner code.