### PR TITLE
CC-2204: Add PHP starter for Git

### DIFF
--- a/compiled_starters/php/.codecrafters/compile.sh
+++ b/compiled_starters/php/.codecrafters/compile.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+# (This file is empty since PHP programs don't use a compile step)

--- a/compiled_starters/php/.codecrafters/run.sh
+++ b/compiled_starters/php/.codecrafters/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+SCRIPT_DIR="$(dirname "$0")"
+exec php "$SCRIPT_DIR/app/main.php" "$@"

--- a/compiled_starters/php/.gitattributes
+++ b/compiled_starters/php/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/compiled_starters/php/README.md
+++ b/compiled_starters/php/README.md
@@ -1,0 +1,59 @@
+![progress-banner](https://codecrafters.io/landing/images/default_progress_banners/git.png)
+
+This is a starting point for PHP solutions to the
+["Build Your Own Git" Challenge](https://codecrafters.io/challenges/git).
+
+In this challenge, you'll build a small Git implementation that's capable of
+initializing a repository, creating commits and cloning a public repository.
+Along the way we'll learn about the `.git` directory, Git objects (blobs,
+commits, trees etc.), Git's transfer protocols and more.
+
+**Note**: If you're viewing this repo on GitHub, head over to
+[codecrafters.io](https://codecrafters.io) to try the challenge.
+
+# Passing the first stage
+
+The entry point for your Git implementation is in `app/main.php`. Study and
+uncomment the relevant code, and push your changes to pass the first stage:
+
+```sh
+git commit -am "pass 1st stage" # any msg
+git push origin master
+```
+
+That's all!
+
+# Stage 2 & beyond
+
+Note: This section is for stages 2 and beyond.
+
+1. Ensure you have `php (8.5)` installed locally
+1. Run `./your_program.sh` to run your Git implementation, which is implemented
+   in `app/main.php`.
+1. Commit your changes and run `git push origin master` to submit your solution
+   to CodeCrafters. Test output will be streamed to your terminal.
+
+# Testing locally
+
+The `your_program.sh` script is expected to operate on the `.git` folder inside
+the current working directory. If you're running this inside the root of this
+repository, you might end up accidentally damaging your repository's `.git`
+folder.
+
+We suggest executing `your_program.sh` in a different folder when testing
+locally. For example:
+
+```sh
+mkdir -p /tmp/testing && cd /tmp/testing
+/path/to/your/repo/your_program.sh init
+```
+
+To make this easier to type out, you could add a
+[shell alias](https://shapeshed.com/unix-alias/):
+
+```sh
+alias mygit=/path/to/your/repo/your_program.sh
+
+mkdir -p /tmp/testing && cd /tmp/testing
+mygit init
+```

--- a/compiled_starters/php/app/main.php
+++ b/compiled_starters/php/app/main.php
@@ -1,0 +1,23 @@
+<?php
+error_reporting(E_ALL);
+
+if (count($argv) < 2) {
+    throw new RuntimeException("No command provided");
+}
+
+// You can use print statements as follows for debugging, they'll be visible when running tests.
+fwrite(STDERR, "Logs from your program will appear here!\n");
+
+// TODO: Uncomment the code below to pass the first stage
+// 
+// $command = $argv[1];
+// if ($command === "init") {
+//     mkdir(".git");
+//     mkdir(".git/objects");
+//     mkdir(".git/refs");
+//     file_put_contents(".git/HEAD", "ref: refs/heads/main\n");
+//     fwrite(STDOUT, "Initialized git directory\n");
+//     return;
+// }
+
+throw new RuntimeException("Unknown command #{$command}");

--- a/compiled_starters/php/codecrafters.yml
+++ b/compiled_starters/php/codecrafters.yml
@@ -1,0 +1,11 @@
+# Set this to true if you want debug logs.
+#
+# These can be VERY verbose, so we suggest turning them off
+# unless you really need them.
+debug: false
+
+# Use this to change the PHP version used to run your code
+# on Codecrafters.
+#
+# Available versions: php-8.5
+buildpack: php-8.5

--- a/compiled_starters/php/your_program.sh
+++ b/compiled_starters/php/your_program.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# Use this script to run your program LOCALLY.
+#
+# Note: Changing this script WILL NOT affect how CodeCrafters runs your program.
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit early if any commands fail
+
+# Copied from .codecrafters/run.sh
+#
+# - Edit this to change how your program runs locally
+# - Edit .codecrafters/run.sh to change how your program runs remotely
+SCRIPT_DIR="$(dirname "$0")"
+exec php "$SCRIPT_DIR/app/main.php" "$@"

--- a/course-definition.yml
+++ b/course-definition.yml
@@ -39,6 +39,7 @@ languages:
   - slug: "java"
     release_status: "beta"
   - slug: "javascript"
+  - slug: "php"
   - slug: "python"
   - slug: "ruby"
   - slug: "rust"

--- a/dockerfiles/php-8.5.Dockerfile
+++ b/dockerfiles/php-8.5.Dockerfile
@@ -1,0 +1,7 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM php:8.5-cli-alpine3.22
+
+# For ext-sockets installation
+RUN apk add linux-headers=~6.14.2-r0 --no-cache
+
+RUN docker-php-ext-install pcntl sockets

--- a/solutions/php/01-gg4/code/.codecrafters/compile.sh
+++ b/solutions/php/01-gg4/code/.codecrafters/compile.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+# (This file is empty since PHP programs don't use a compile step)

--- a/solutions/php/01-gg4/code/.codecrafters/run.sh
+++ b/solutions/php/01-gg4/code/.codecrafters/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+SCRIPT_DIR="$(dirname "$0")"
+exec php "$SCRIPT_DIR/app/main.php" "$@"

--- a/solutions/php/01-gg4/code/.gitattributes
+++ b/solutions/php/01-gg4/code/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/solutions/php/01-gg4/code/README.md
+++ b/solutions/php/01-gg4/code/README.md
@@ -1,0 +1,59 @@
+![progress-banner](https://codecrafters.io/landing/images/default_progress_banners/git.png)
+
+This is a starting point for PHP solutions to the
+["Build Your Own Git" Challenge](https://codecrafters.io/challenges/git).
+
+In this challenge, you'll build a small Git implementation that's capable of
+initializing a repository, creating commits and cloning a public repository.
+Along the way we'll learn about the `.git` directory, Git objects (blobs,
+commits, trees etc.), Git's transfer protocols and more.
+
+**Note**: If you're viewing this repo on GitHub, head over to
+[codecrafters.io](https://codecrafters.io) to try the challenge.
+
+# Passing the first stage
+
+The entry point for your Git implementation is in `app/main.php`. Study and
+uncomment the relevant code, and push your changes to pass the first stage:
+
+```sh
+git commit -am "pass 1st stage" # any msg
+git push origin master
+```
+
+That's all!
+
+# Stage 2 & beyond
+
+Note: This section is for stages 2 and beyond.
+
+1. Ensure you have `php (8.5)` installed locally
+1. Run `./your_program.sh` to run your Git implementation, which is implemented
+   in `app/main.php`.
+1. Commit your changes and run `git push origin master` to submit your solution
+   to CodeCrafters. Test output will be streamed to your terminal.
+
+# Testing locally
+
+The `your_program.sh` script is expected to operate on the `.git` folder inside
+the current working directory. If you're running this inside the root of this
+repository, you might end up accidentally damaging your repository's `.git`
+folder.
+
+We suggest executing `your_program.sh` in a different folder when testing
+locally. For example:
+
+```sh
+mkdir -p /tmp/testing && cd /tmp/testing
+/path/to/your/repo/your_program.sh init
+```
+
+To make this easier to type out, you could add a
+[shell alias](https://shapeshed.com/unix-alias/):
+
+```sh
+alias mygit=/path/to/your/repo/your_program.sh
+
+mkdir -p /tmp/testing && cd /tmp/testing
+mygit init
+```

--- a/solutions/php/01-gg4/code/app/main.php
+++ b/solutions/php/01-gg4/code/app/main.php
@@ -1,0 +1,18 @@
+<?php
+error_reporting(E_ALL);
+
+if (count($argv) < 2) {
+    throw new RuntimeException("No command provided");
+}
+
+$command = $argv[1];
+if ($command === "init") {
+    mkdir(".git");
+    mkdir(".git/objects");
+    mkdir(".git/refs");
+    file_put_contents(".git/HEAD", "ref: refs/heads/main\n");
+    fwrite(STDOUT, "Initialized git directory\n");
+    return;
+}
+
+throw new RuntimeException("Unknown command #{$command}");

--- a/solutions/php/01-gg4/code/codecrafters.yml
+++ b/solutions/php/01-gg4/code/codecrafters.yml
@@ -1,0 +1,11 @@
+# Set this to true if you want debug logs.
+#
+# These can be VERY verbose, so we suggest turning them off
+# unless you really need them.
+debug: false
+
+# Use this to change the PHP version used to run your code
+# on Codecrafters.
+#
+# Available versions: php-8.5
+buildpack: php-8.5

--- a/solutions/php/01-gg4/code/your_program.sh
+++ b/solutions/php/01-gg4/code/your_program.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# Use this script to run your program LOCALLY.
+#
+# Note: Changing this script WILL NOT affect how CodeCrafters runs your program.
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit early if any commands fail
+
+# Copied from .codecrafters/run.sh
+#
+# - Edit this to change how your program runs locally
+# - Edit .codecrafters/run.sh to change how your program runs remotely
+SCRIPT_DIR="$(dirname "$0")"
+exec php "$SCRIPT_DIR/app/main.php" "$@"

--- a/solutions/php/01-gg4/diff/app/main.php.diff
+++ b/solutions/php/01-gg4/diff/app/main.php.diff
@@ -1,0 +1,34 @@
+@@ -1,23 +1,18 @@
+ <?php
+ error_reporting(E_ALL);
+
+ if (count($argv) < 2) {
+     throw new RuntimeException("No command provided");
+ }
+
+-// You can use print statements as follows for debugging, they'll be visible when running tests.
+-fwrite(STDERR, "Logs from your program will appear here!\n");
+-
+-// TODO: Uncomment the code below to pass the first stage
+-// 
+-// $command = $argv[1];
+-// if ($command === "init") {
+-//     mkdir(".git");
+-//     mkdir(".git/objects");
+-//     mkdir(".git/refs");
+-//     file_put_contents(".git/HEAD", "ref: refs/heads/main\n");
+-//     fwrite(STDOUT, "Initialized git directory\n");
+-//     return;
+-// }
++$command = $argv[1];
++if ($command === "init") {
++    mkdir(".git");
++    mkdir(".git/objects");
++    mkdir(".git/refs");
++    file_put_contents(".git/HEAD", "ref: refs/heads/main\n");
++    fwrite(STDOUT, "Initialized git directory\n");
++    return;
++}
+
+ throw new RuntimeException("Unknown command #{$command}");
+\ No newline at end of file

--- a/starter_templates/php/code/.codecrafters/compile.sh
+++ b/starter_templates/php/code/.codecrafters/compile.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+# (This file is empty since PHP programs don't use a compile step)

--- a/starter_templates/php/code/.codecrafters/run.sh
+++ b/starter_templates/php/code/.codecrafters/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+SCRIPT_DIR="$(dirname "$0")"
+exec php "$SCRIPT_DIR/app/main.php" "$@"

--- a/starter_templates/php/code/app/main.php
+++ b/starter_templates/php/code/app/main.php
@@ -1,0 +1,23 @@
+<?php
+error_reporting(E_ALL);
+
+if (count($argv) < 2) {
+    throw new RuntimeException("No command provided");
+}
+
+// You can use print statements as follows for debugging, they'll be visible when running tests.
+fwrite(STDERR, "Logs from your program will appear here!\n");
+
+// TODO: Uncomment the code below to pass the first stage
+// 
+// $command = $argv[1];
+// if ($command === "init") {
+//     mkdir(".git");
+//     mkdir(".git/objects");
+//     mkdir(".git/refs");
+//     file_put_contents(".git/HEAD", "ref: refs/heads/main\n");
+//     fwrite(STDOUT, "Initialized git directory\n");
+//     return;
+// }
+
+throw new RuntimeException("Unknown command #{$command}");

--- a/starter_templates/php/config.yml
+++ b/starter_templates/php/config.yml
@@ -1,0 +1,3 @@
+attributes:
+  required_executable: "php (8.5)"
+  user_editable_file: "app/main.php"


### PR DESCRIPTION
- Created a new PHP starter template with necessary files including README, configuration, and scripts for local execution.
- Implemented basic functionality in `app/main.php` to initialize a Git directory.
- Added `.gitattributes` and `codecrafters.yml` for project configuration.
- Included scripts for compiling and running the program on CodeCrafters platform.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly additive scaffolding, but it introduces a new runtime Dockerfile and course language entry that could affect build/runner behavior for the new PHP track if misconfigured.
> 
> **Overview**
> Adds **PHP (8.5) as a supported language** for the Git challenge, including new `starter_templates/php` and `compiled_starters/php` scaffolding (runner scripts, `codecrafters.yml`, `your_program.sh`, `.gitattributes`, and README).
> 
> Introduces a `php-8.5` Docker image definition (Alpine) with required extensions, and updates `course-definition.yml` to include the new `php` language. Also adds a reference solution for stage `gg4` with `app/main.php` implementing `init` (creates `.git` structure and HEAD).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a073859ae59ff34920c64315b105c095c9bc73f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->