### PR TITLE
CC-2189: Upgrade Rust to v1.94

### DIFF
--- a/compiled_starters/rust/Cargo.toml
+++ b/compiled_starters/rust/Cargo.toml
@@ -3,7 +3,7 @@ name = "codecrafters-git"
 version = "0.1.0"
 authors = ["Codecrafters <hello@codecrafters.io>"]
 edition = "2024"
-rust-version = "1.91"
+rust-version = "1.94"
 
 [dependencies]
 anyhow = "1.0.68"                                # error handling

--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -27,7 +27,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.93)` installed locally
+1. Ensure you have `cargo (1.94)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `src/main.rs`. This command compiles your Rust project, so it might be
    slow the first time you run it. Subsequent runs will be fast.

--- a/compiled_starters/rust/codecrafters.yml
+++ b/compiled_starters/rust/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.93
-buildpack: rust-1.93
+# Available versions: rust-1.94
+buildpack: rust-1.94

--- a/dockerfiles/rust-1.94.Dockerfile
+++ b/dockerfiles/rust-1.94.Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM rust:1.94-trixie
+
+# Rebuild the container if these files change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="Cargo.toml,Cargo.lock"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# This runs cargo build
+RUN .codecrafters/compile.sh

--- a/solutions/rust/01-gg4/code/Cargo.toml
+++ b/solutions/rust/01-gg4/code/Cargo.toml
@@ -3,7 +3,7 @@ name = "codecrafters-git"
 version = "0.1.0"
 authors = ["Codecrafters <hello@codecrafters.io>"]
 edition = "2024"
-rust-version = "1.91"
+rust-version = "1.94"
 
 [dependencies]
 anyhow = "1.0.68"                                # error handling

--- a/solutions/rust/01-gg4/code/README.md
+++ b/solutions/rust/01-gg4/code/README.md
@@ -27,7 +27,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.93)` installed locally
+1. Ensure you have `cargo (1.94)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `src/main.rs`. This command compiles your Rust project, so it might be
    slow the first time you run it. Subsequent runs will be fast.

--- a/solutions/rust/01-gg4/code/codecrafters.yml
+++ b/solutions/rust/01-gg4/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.93
-buildpack: rust-1.93
+# Available versions: rust-1.94
+buildpack: rust-1.94

--- a/starter_templates/rust/code/Cargo.toml
+++ b/starter_templates/rust/code/Cargo.toml
@@ -3,7 +3,7 @@ name = "codecrafters-git"
 version = "0.1.0"
 authors = ["Codecrafters <hello@codecrafters.io>"]
 edition = "2024"
-rust-version = "1.91"
+rust-version = "1.94"
 
 [dependencies]
 anyhow = "1.0.68"                                # error handling

--- a/starter_templates/rust/config.yml
+++ b/starter_templates/rust/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: cargo (1.93)
+  required_executable: cargo (1.94)
   user_editable_file: src/main.rs


### PR DESCRIPTION
CC-2189: Upgrade Rust to v1.94

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a toolchain/config bump, but it can affect build/CI behavior and compatibility for users still on older Rust/Cargo versions.
> 
> **Overview**
> Upgrades the Rust starter templates and example solution to require `rust-version = 1.94`, and updates the documented local `cargo` requirement from `1.93` to `1.94`.
> 
> Switches the Codecrafters runtime buildpack from `rust-1.93` to `rust-1.94` and adds a new `dockerfiles/rust-1.94.Dockerfile` to build/test against the updated toolchain.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72ea8bd11dfe78812bf3a56d032b240f80987962. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->