### PR TITLE
CC-2260: Upgrade Rust to v1.95

### DIFF
--- a/compiled_starters/rust/Cargo.toml
+++ b/compiled_starters/rust/Cargo.toml
@@ -3,7 +3,7 @@ name = "codecrafters-git"
 version = "0.1.0"
 authors = ["Codecrafters <hello@codecrafters.io>"]
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.95"
 
 [dependencies]
 anyhow = "1.0.68"                                # error handling

--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -27,7 +27,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.94)` installed locally
+1. Ensure you have `cargo (1.95)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `src/main.rs`. This command compiles your Rust project, so it might be
    slow the first time you run it. Subsequent runs will be fast.

--- a/compiled_starters/rust/codecrafters.yml
+++ b/compiled_starters/rust/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.94
-buildpack: rust-1.94
+# Available versions: rust-1.95
+buildpack: rust-1.95

--- a/dockerfiles/rust-1.95.Dockerfile
+++ b/dockerfiles/rust-1.95.Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM rust:1.95-trixie
+
+# Rebuild the container if these files change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="Cargo.toml,Cargo.lock"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# This runs cargo build
+RUN .codecrafters/compile.sh

--- a/solutions/rust/01-gg4/code/Cargo.toml
+++ b/solutions/rust/01-gg4/code/Cargo.toml
@@ -3,7 +3,7 @@ name = "codecrafters-git"
 version = "0.1.0"
 authors = ["Codecrafters <hello@codecrafters.io>"]
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.95"
 
 [dependencies]
 anyhow = "1.0.68"                                # error handling

--- a/solutions/rust/01-gg4/code/README.md
+++ b/solutions/rust/01-gg4/code/README.md
@@ -27,7 +27,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.94)` installed locally
+1. Ensure you have `cargo (1.95)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `src/main.rs`. This command compiles your Rust project, so it might be
    slow the first time you run it. Subsequent runs will be fast.

--- a/solutions/rust/01-gg4/code/codecrafters.yml
+++ b/solutions/rust/01-gg4/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.94
-buildpack: rust-1.94
+# Available versions: rust-1.95
+buildpack: rust-1.95

--- a/starter_templates/rust/code/Cargo.toml
+++ b/starter_templates/rust/code/Cargo.toml
@@ -3,7 +3,7 @@ name = "codecrafters-git"
 version = "0.1.0"
 authors = ["Codecrafters <hello@codecrafters.io>"]
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.95"
 
 [dependencies]
 anyhow = "1.0.68"                                # error handling

--- a/starter_templates/rust/config.yml
+++ b/starter_templates/rust/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: cargo (1.94)
+  required_executable: cargo (1.95)
   user_editable_file: src/main.rs


### PR DESCRIPTION
CC-2260: Upgrade Rust to v1.95

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily a tooling/version bump, but changing the Rust toolchain and buildpack can cause unexpected build or dependency compatibility issues in the starter environments.
> 
> **Overview**
> Upgrades the Rust starter/solution toolchain from **1.94 to 1.95** by updating `rust-version` in Rust `Cargo.toml` files, the required `cargo` version in READMEs and `starter_templates/rust/config.yml`, and the Codecrafters buildpack setting.
> 
> Adds a new `dockerfiles/rust-1.95.Dockerfile` to build/run the Rust environment on Rust 1.95 (mirroring the prior 1.94 image setup).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81955668c8b443f959e131ea113b537822fc4a81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->