### PR TITLE
CC-2191: Upgrade Ruby to v4

### DIFF
--- a/compiled_starters/ruby/Gemfile.lock
+++ b/compiled_starters/ruby/Gemfile.lock
@@ -6,10 +6,10 @@ PLATFORMS
   aarch64-linux-musl
   arm64-darwin-21
   arm64-darwin-23
-  x86_64-linux
   ruby
+  x86_64-linux
 
 DEPENDENCIES
 
 BUNDLED WITH
-   2.5.6
+  4.0.10

--- a/solutions/ruby/01-gg4/code/Gemfile.lock
+++ b/solutions/ruby/01-gg4/code/Gemfile.lock
@@ -6,10 +6,10 @@ PLATFORMS
   aarch64-linux-musl
   arm64-darwin-21
   arm64-darwin-23
-  x86_64-linux
   ruby
+  x86_64-linux
 
 DEPENDENCIES
 
 BUNDLED WITH
-   2.5.6
+  4.0.10

--- a/starter_templates/ruby/code/Gemfile.lock
+++ b/starter_templates/ruby/code/Gemfile.lock
@@ -6,10 +6,10 @@ PLATFORMS
   aarch64-linux-musl
   arm64-darwin-21
   arm64-darwin-23
-  x86_64-linux
   ruby
+  x86_64-linux
 
 DEPENDENCIES
 
 BUNDLED WITH
-   2.5.6
+  4.0.10


### PR DESCRIPTION
CC-2191: Upgrade Ruby to v4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Updates only `Gemfile.lock` metadata (Bundler version/platform ordering) with no application code changes. Risk is limited to build/environment compatibility where older Bundler versions may no longer match the lockfiles.
> 
> **Overview**
> Updates the Ruby starter/template/solution `Gemfile.lock` files to use **Bundler `4.0.10`** (from `2.5.6`) and refreshes the `PLATFORMS` section ordering (ensuring `x86_64-linux` is listed).
> 
> No gem dependencies change; this is a lockfile metadata update intended to align Ruby artifacts with the newer Bundler toolchain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0ddb937a29bf407c24428f37dfdd3271e2030ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->