### PR TITLE
CC-2266: Add Elixir starter for Git challenge

### DIFF
--- a/compiled_starters/elixir/.codecrafters/compile.sh
+++ b/compiled_starters/elixir/.codecrafters/compile.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+mix escript.build
+mv codecrafters_git /tmp/codecrafters-build-git-elixir

--- a/compiled_starters/elixir/.codecrafters/run.sh
+++ b/compiled_starters/elixir/.codecrafters/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+exec /tmp/codecrafters-build-git-elixir "$@"

--- a/compiled_starters/elixir/.formatter.exs
+++ b/compiled_starters/elixir/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/compiled_starters/elixir/.gitattributes
+++ b/compiled_starters/elixir/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/compiled_starters/elixir/.gitignore
+++ b/compiled_starters/elixir/.gitignore
@@ -1,0 +1,27 @@
+# Ignore the compiled binary
+/codecrafters_git
+
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+app-*.tar
+

--- a/compiled_starters/elixir/README.md
+++ b/compiled_starters/elixir/README.md
@@ -1,0 +1,59 @@
+![progress-banner](https://codecrafters.io/landing/images/default_progress_banners/git.png)
+
+This is a starting point for Elixir solutions to the
+["Build Your Own Git" Challenge](https://codecrafters.io/challenges/git).
+
+In this challenge, you'll build a small Git implementation that's capable of
+initializing a repository, creating commits and cloning a public repository.
+Along the way we'll learn about the `.git` directory, Git objects (blobs,
+commits, trees etc.), Git's transfer protocols and more.
+
+**Note**: If you're viewing this repo on GitHub, head over to
+[codecrafters.io](https://codecrafters.io) to try the challenge.
+
+# Passing the first stage
+
+The entry point for your Git implementation is in `lib/main.ex`. Study and
+uncomment the relevant code, and push your changes to pass the first stage:
+
+```sh
+git commit -am "pass 1st stage" # any msg
+git push origin master
+```
+
+That's all!
+
+# Stage 2 & beyond
+
+Note: This section is for stages 2 and beyond.
+
+1. Ensure you have `mix` installed locally
+1. Run `./your_program.sh` to run your Git implementation, which is implemented
+   in `lib/main.ex`.
+1. Commit your changes and run `git push origin master` to submit your solution
+   to CodeCrafters. Test output will be streamed to your terminal.
+
+# Testing locally
+
+The `your_program.sh` script is expected to operate on the `.git` folder inside
+the current working directory. If you're running this inside the root of this
+repository, you might end up accidentally damaging your repository's `.git`
+folder.
+
+We suggest executing `your_program.sh` in a different folder when testing
+locally. For example:
+
+```sh
+mkdir -p /tmp/testing && cd /tmp/testing
+/path/to/your/repo/your_program.sh init
+```
+
+To make this easier to type out, you could add a
+[shell alias](https://shapeshed.com/unix-alias/):
+
+```sh
+alias mygit=/path/to/your/repo/your_program.sh
+
+mkdir -p /tmp/testing && cd /tmp/testing
+mygit init
+```

--- a/compiled_starters/elixir/codecrafters.yml
+++ b/compiled_starters/elixir/codecrafters.yml
@@ -1,0 +1,11 @@
+# Set this to true if you want debug logs.
+#
+# These can be VERY verbose, so we suggest turning them off
+# unless you really need them.
+debug: false
+
+# Use this to change the Elixir version used to run your code
+# on Codecrafters.
+#
+# Available versions: elixir-1.19
+buildpack: elixir-1.19

--- a/compiled_starters/elixir/lib/main.ex
+++ b/compiled_starters/elixir/lib/main.ex
@@ -1,0 +1,21 @@
+defmodule CLI do
+  def main(args) do
+    # You can use print statements as follows for debugging, they'll be visible when running tests.
+    IO.puts(:stderr, "Logs from your program will appear here!")
+
+    # TODO: Uncomment the code below to pass the first stage
+    #
+    # command = List.first(args)
+    # case command do
+    #   "init" ->
+    #     File.mkdir!(".git")
+    #     File.mkdir!(".git/objects")
+    #     File.mkdir!(".git/refs")
+    #     File.write!(".git/HEAD", "ref: refs/heads/main\n")
+    #     IO.puts("Initialized git directory")
+    #
+    #   _ ->
+    #     raise "Unknown command #{command}"
+    # end
+  end
+end

--- a/compiled_starters/elixir/mix.exs
+++ b/compiled_starters/elixir/mix.exs
@@ -1,0 +1,30 @@
+defmodule App.MixProject do
+  # NOTE: You do not need to change anything in this file.
+  use Mix.Project
+
+  def project do
+    [
+      app: :codecrafters_git,
+      version: "1.0.0",
+      elixir: "~> 1.19",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      escript: [main_module: CLI]
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+    ]
+  end
+end

--- a/compiled_starters/elixir/your_program.sh
+++ b/compiled_starters/elixir/your_program.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# Use this script to run your program LOCALLY.
+#
+# Note: Changing this script WILL NOT affect how CodeCrafters runs your program.
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit early if any commands fail
+
+# Copied from .codecrafters/compile.sh
+#
+# - Edit this to change how your program compiles locally
+# - Edit .codecrafters/compile.sh to change how your program compiles remotely
+(
+  cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
+  mix escript.build
+  mv codecrafters_git /tmp/codecrafters-build-git-elixir
+)
+
+# Copied from .codecrafters/run.sh
+#
+# - Edit this to change how your program runs locally
+# - Edit .codecrafters/run.sh to change how your program runs remotely
+exec /tmp/codecrafters-build-git-elixir "$@"

--- a/course-definition.yml
+++ b/course-definition.yml
@@ -34,6 +34,7 @@ languages:
   - slug: "cpp"
   - slug: "csharp"
     release_status: "beta"
+  - slug: "elixir"
   - slug: "go"
   - slug: "haskell"
   - slug: "java"

--- a/dockerfiles/elixir-1.19.Dockerfile
+++ b/dockerfiles/elixir-1.19.Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM elixir:1.19.5-alpine
+
+# Ensures the container is re-built if dependency files change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="mix.exs,mix.lock"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# install hex + rebar
+RUN mix local.hex --force && \
+  mix local.rebar --force
+
+# install and compile mix dependencies
+RUN mix deps.get && \
+  mix deps.compile
+
+# Install & cache deps
+RUN .codecrafters/compile.sh
+
+RUN mkdir -p /app-cached
+RUN if [ -d "/app/_build" ]; then mv /app/_build /app-cached; fi
+RUN if [ -d "/app/deps" ]; then mv /app/deps /app-cached; fi

--- a/solutions/elixir/01-gg4/code/.codecrafters/compile.sh
+++ b/solutions/elixir/01-gg4/code/.codecrafters/compile.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+mix escript.build
+mv codecrafters_git /tmp/codecrafters-build-git-elixir

--- a/solutions/elixir/01-gg4/code/.codecrafters/run.sh
+++ b/solutions/elixir/01-gg4/code/.codecrafters/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+exec /tmp/codecrafters-build-git-elixir "$@"

--- a/solutions/elixir/01-gg4/code/.formatter.exs
+++ b/solutions/elixir/01-gg4/code/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/solutions/elixir/01-gg4/code/.gitattributes
+++ b/solutions/elixir/01-gg4/code/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/solutions/elixir/01-gg4/code/.gitignore
+++ b/solutions/elixir/01-gg4/code/.gitignore
@@ -1,0 +1,27 @@
+# Ignore the compiled binary
+/codecrafters_git
+
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+app-*.tar
+

--- a/solutions/elixir/01-gg4/code/README.md
+++ b/solutions/elixir/01-gg4/code/README.md
@@ -1,0 +1,59 @@
+![progress-banner](https://codecrafters.io/landing/images/default_progress_banners/git.png)
+
+This is a starting point for Elixir solutions to the
+["Build Your Own Git" Challenge](https://codecrafters.io/challenges/git).
+
+In this challenge, you'll build a small Git implementation that's capable of
+initializing a repository, creating commits and cloning a public repository.
+Along the way we'll learn about the `.git` directory, Git objects (blobs,
+commits, trees etc.), Git's transfer protocols and more.
+
+**Note**: If you're viewing this repo on GitHub, head over to
+[codecrafters.io](https://codecrafters.io) to try the challenge.
+
+# Passing the first stage
+
+The entry point for your Git implementation is in `lib/main.ex`. Study and
+uncomment the relevant code, and push your changes to pass the first stage:
+
+```sh
+git commit -am "pass 1st stage" # any msg
+git push origin master
+```
+
+That's all!
+
+# Stage 2 & beyond
+
+Note: This section is for stages 2 and beyond.
+
+1. Ensure you have `mix` installed locally
+1. Run `./your_program.sh` to run your Git implementation, which is implemented
+   in `lib/main.ex`.
+1. Commit your changes and run `git push origin master` to submit your solution
+   to CodeCrafters. Test output will be streamed to your terminal.
+
+# Testing locally
+
+The `your_program.sh` script is expected to operate on the `.git` folder inside
+the current working directory. If you're running this inside the root of this
+repository, you might end up accidentally damaging your repository's `.git`
+folder.
+
+We suggest executing `your_program.sh` in a different folder when testing
+locally. For example:
+
+```sh
+mkdir -p /tmp/testing && cd /tmp/testing
+/path/to/your/repo/your_program.sh init
+```
+
+To make this easier to type out, you could add a
+[shell alias](https://shapeshed.com/unix-alias/):
+
+```sh
+alias mygit=/path/to/your/repo/your_program.sh
+
+mkdir -p /tmp/testing && cd /tmp/testing
+mygit init
+```

--- a/solutions/elixir/01-gg4/code/codecrafters.yml
+++ b/solutions/elixir/01-gg4/code/codecrafters.yml
@@ -1,0 +1,11 @@
+# Set this to true if you want debug logs.
+#
+# These can be VERY verbose, so we suggest turning them off
+# unless you really need them.
+debug: false
+
+# Use this to change the Elixir version used to run your code
+# on Codecrafters.
+#
+# Available versions: elixir-1.19
+buildpack: elixir-1.19

--- a/solutions/elixir/01-gg4/code/lib/main.ex
+++ b/solutions/elixir/01-gg4/code/lib/main.ex
@@ -1,0 +1,16 @@
+defmodule CLI do
+  def main(args) do
+    command = List.first(args)
+    case command do
+      "init" ->
+        File.mkdir!(".git")
+        File.mkdir!(".git/objects")
+        File.mkdir!(".git/refs")
+        File.write!(".git/HEAD", "ref: refs/heads/main\n")
+        IO.puts("Initialized git directory")
+
+      _ ->
+        raise "Unknown command #{command}"
+    end
+  end
+end

--- a/solutions/elixir/01-gg4/code/mix.exs
+++ b/solutions/elixir/01-gg4/code/mix.exs
@@ -1,0 +1,30 @@
+defmodule App.MixProject do
+  # NOTE: You do not need to change anything in this file.
+  use Mix.Project
+
+  def project do
+    [
+      app: :codecrafters_git,
+      version: "1.0.0",
+      elixir: "~> 1.19",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      escript: [main_module: CLI]
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+    ]
+  end
+end

--- a/solutions/elixir/01-gg4/code/your_program.sh
+++ b/solutions/elixir/01-gg4/code/your_program.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# Use this script to run your program LOCALLY.
+#
+# Note: Changing this script WILL NOT affect how CodeCrafters runs your program.
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit early if any commands fail
+
+# Copied from .codecrafters/compile.sh
+#
+# - Edit this to change how your program compiles locally
+# - Edit .codecrafters/compile.sh to change how your program compiles remotely
+(
+  cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
+  mix escript.build
+  mv codecrafters_git /tmp/codecrafters-build-git-elixir
+)
+
+# Copied from .codecrafters/run.sh
+#
+# - Edit this to change how your program runs locally
+# - Edit .codecrafters/run.sh to change how your program runs remotely
+exec /tmp/codecrafters-build-git-elixir "$@"

--- a/solutions/elixir/01-gg4/diff/lib/main.ex.diff
+++ b/solutions/elixir/01-gg4/diff/lib/main.ex.diff
@@ -1,0 +1,33 @@
+@@ -1,21 +1,16 @@
+ defmodule CLI do
+   def main(args) do
+-    # You can use print statements as follows for debugging, they'll be visible when running tests.
+-    IO.puts(:stderr, "Logs from your program will appear here!")
++    command = List.first(args)
++    case command do
++      "init" ->
++        File.mkdir!(".git")
++        File.mkdir!(".git/objects")
++        File.mkdir!(".git/refs")
++        File.write!(".git/HEAD", "ref: refs/heads/main\n")
++        IO.puts("Initialized git directory")
+
+-    # TODO: Uncomment the code below to pass the first stage
+-    #
+-    # command = List.first(args)
+-    # case command do
+-    #   "init" ->
+-    #     File.mkdir!(".git")
+-    #     File.mkdir!(".git/objects")
+-    #     File.mkdir!(".git/refs")
+-    #     File.write!(".git/HEAD", "ref: refs/heads/main\n")
+-    #     IO.puts("Initialized git directory")
+-    #
+-    #   _ ->
+-    #     raise "Unknown command #{command}"
+-    # end
++      _ ->
++        raise "Unknown command #{command}"
++    end
+   end
+ end

--- a/starter_templates/elixir/code/.codecrafters/compile.sh
+++ b/starter_templates/elixir/code/.codecrafters/compile.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+mix escript.build
+mv codecrafters_git /tmp/codecrafters-build-git-elixir

--- a/starter_templates/elixir/code/.codecrafters/run.sh
+++ b/starter_templates/elixir/code/.codecrafters/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+exec /tmp/codecrafters-build-git-elixir "$@"

--- a/starter_templates/elixir/code/.formatter.exs
+++ b/starter_templates/elixir/code/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/starter_templates/elixir/code/.gitignore
+++ b/starter_templates/elixir/code/.gitignore
@@ -1,0 +1,27 @@
+# Ignore the compiled binary
+/codecrafters_git
+
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+app-*.tar
+

--- a/starter_templates/elixir/code/lib/main.ex
+++ b/starter_templates/elixir/code/lib/main.ex
@@ -1,0 +1,21 @@
+defmodule CLI do
+  def main(args) do
+    # You can use print statements as follows for debugging, they'll be visible when running tests.
+    IO.puts(:stderr, "Logs from your program will appear here!")
+
+    # TODO: Uncomment the code below to pass the first stage
+    #
+    # command = List.first(args)
+    # case command do
+    #   "init" ->
+    #     File.mkdir!(".git")
+    #     File.mkdir!(".git/objects")
+    #     File.mkdir!(".git/refs")
+    #     File.write!(".git/HEAD", "ref: refs/heads/main\n")
+    #     IO.puts("Initialized git directory")
+    #
+    #   _ ->
+    #     raise "Unknown command #{command}"
+    # end
+  end
+end

--- a/starter_templates/elixir/code/mix.exs
+++ b/starter_templates/elixir/code/mix.exs
@@ -1,0 +1,30 @@
+defmodule App.MixProject do
+  # NOTE: You do not need to change anything in this file.
+  use Mix.Project
+
+  def project do
+    [
+      app: :codecrafters_git,
+      version: "1.0.0",
+      elixir: "~> 1.19",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      escript: [main_module: CLI]
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+    ]
+  end
+end

--- a/starter_templates/elixir/config.yml
+++ b/starter_templates/elixir/config.yml
@@ -1,0 +1,3 @@
+attributes:
+  required_executable: "mix"
+  user_editable_file: "lib/main.ex"


### PR DESCRIPTION
- Created a new Elixir starter template with essential files including README, configuration, and scripts for local execution.
- Implemented initial functionality in `lib/main.ex` to initialize a Git directory.
- Added `.gitattributes`, `.gitignore`, and `codecrafters.yml` for project configuration.
- Included scripts for compiling and running the program on the CodeCrafters platform.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily adds new template/config files and build/run plumbing; impact is limited to enabling a new language and its container build.
> 
> **Overview**
> Introduces **Elixir support for the Git challenge** by adding new starter/compiled starter assets and a sample solution for stage `gg4`.
> 
> Adds CodeCrafters build/run scripts that compile an Elixir `escript` via `mix escript.build` and execute the produced binary, plus supporting project files (`mix.exs`, `.formatter.exs`, ignores, README, `codecrafters.yml`).
> 
> Wires the language into the course by adding `elixir` to `course-definition.yml` and provides a new `elixir-1.19` Docker image definition to build/cache dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d400e346d3cac9a5683872aa7d6ef62895735b02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->