### PR TITLE
https://linear.app/codecrafters/issue/CC-2159/replace-git-commands-in-readmes-as-cc-submit

### DIFF
--- a/compiled_starters/c/README.md
+++ b/compiled_starters/c/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `src/main.c`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/compiled_starters/cpp/README.md
+++ b/compiled_starters/cpp/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `src/main.cpp`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/compiled_starters/csharp/README.md
+++ b/compiled_starters/csharp/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `dotnet (9.0)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `src/Program.cs`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/compiled_starters/elixir/README.md
+++ b/compiled_starters/elixir/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mix` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `lib/main.ex`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/compiled_starters/go/README.md
+++ b/compiled_starters/go/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `go (1.26)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `app/main.go`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/compiled_starters/haskell/README.md
+++ b/compiled_starters/haskell/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `stack (23.18)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `app/Main.hs`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/compiled_starters/java/README.md
+++ b/compiled_starters/java/README.md
@@ -31,8 +31,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mvn` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `src/main/java/Main.java`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/compiled_starters/javascript/README.md
+++ b/compiled_starters/javascript/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `node (25)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `app/main.js`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/compiled_starters/kotlin/README.md
+++ b/compiled_starters/kotlin/README.md
@@ -31,8 +31,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `gradle (9.4.1)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `app/src/main/kotlin/App.kt`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/compiled_starters/ocaml/README.md
+++ b/compiled_starters/ocaml/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `dune` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `src/main.ml`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/compiled_starters/php/README.md
+++ b/compiled_starters/php/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `php (8.5)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `app/main.php`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/compiled_starters/python/README.md
+++ b/compiled_starters/python/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `uv` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `app/main.py`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/compiled_starters/ruby/README.md
+++ b/compiled_starters/ruby/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `ruby (4.0)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `app/main.rb`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -31,8 +31,8 @@ Note: This section is for stages 2 and beyond.
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `src/main.rs`. This command compiles your Rust project, so it might be
    slow the first time you run it. Subsequent runs will be fast.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/compiled_starters/typescript/README.md
+++ b/compiled_starters/typescript/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `bun (1.3)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `app/main.ts`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/compiled_starters/zig/README.md
+++ b/compiled_starters/zig/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `zig (0.15)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `src/main.zig`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/solutions/c/01-gg4/code/README.md
+++ b/solutions/c/01-gg4/code/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `src/main.c`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/solutions/cpp/01-gg4/code/README.md
+++ b/solutions/cpp/01-gg4/code/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `src/main.cpp`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/solutions/csharp/01-gg4/code/README.md
+++ b/solutions/csharp/01-gg4/code/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `dotnet (9.0)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `src/Program.cs`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/solutions/elixir/01-gg4/code/README.md
+++ b/solutions/elixir/01-gg4/code/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mix` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `lib/main.ex`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/solutions/go/01-gg4/code/README.md
+++ b/solutions/go/01-gg4/code/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `go (1.26)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `app/main.go`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/solutions/haskell/01-gg4/code/README.md
+++ b/solutions/haskell/01-gg4/code/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `stack (23.18)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `app/Main.hs`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/solutions/java/01-gg4/code/README.md
+++ b/solutions/java/01-gg4/code/README.md
@@ -31,8 +31,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mvn` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `src/main/java/Main.java`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/solutions/javascript/01-gg4/code/README.md
+++ b/solutions/javascript/01-gg4/code/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `node (25)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `app/main.js`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/solutions/kotlin/01-gg4/code/README.md
+++ b/solutions/kotlin/01-gg4/code/README.md
@@ -31,8 +31,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `gradle (9.4.1)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `app/src/main/kotlin/App.kt`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/solutions/ocaml/01-gg4/code/README.md
+++ b/solutions/ocaml/01-gg4/code/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `dune` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `src/main.ml`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/solutions/php/01-gg4/code/README.md
+++ b/solutions/php/01-gg4/code/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `php (8.5)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `app/main.php`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/solutions/python/01-gg4/code/README.md
+++ b/solutions/python/01-gg4/code/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `uv` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `app/main.py`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/solutions/ruby/01-gg4/code/README.md
+++ b/solutions/ruby/01-gg4/code/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `ruby (4.0)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `app/main.rb`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/solutions/rust/01-gg4/code/README.md
+++ b/solutions/rust/01-gg4/code/README.md
@@ -31,8 +31,8 @@ Note: This section is for stages 2 and beyond.
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `src/main.rs`. This command compiles your Rust project, so it might be
    slow the first time you run it. Subsequent runs will be fast.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/solutions/typescript/01-gg4/code/README.md
+++ b/solutions/typescript/01-gg4/code/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `bun (1.3)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `app/main.ts`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/solutions/zig/01-gg4/code/README.md
+++ b/solutions/zig/01-gg4/code/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `zig (0.15)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `src/main.zig`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Testing locally
 

--- a/starter_templates/all/code/README.md
+++ b/starter_templates/all/code/README.md
@@ -32,8 +32,7 @@ Note: This section is for stages 2 and beyond.
    `{{ user_editable_file }}`.{{# language_is_rust }} This command compiles your
    Rust project, so it might be slow the first time you run it. Subsequent runs
    will be fast.{{/ language_is_rust}}
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test output will be streamed to your terminal.
 
 # Testing locally
 


### PR DESCRIPTION
https://linear.app/codecrafters/issue/CC-2159/replace-git-commands-in-readmes-as-cc-submit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates submission instructions; no runtime or build behavior is affected.
> 
> **Overview**
> Updates the *Stage 2 & beyond* instructions across all compiled starter and solution README files to submit via `codecrafters submit` instead of committing and pushing to `master`.
> 
> Also applies the same change to the shared `starter_templates/all/code/README.md` so future generated READMEs use the new submission command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da341290ea0db7327dd8a46e37e3e4704d06eed6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->