### PR TITLE
CC-2281: Upgrade Rust to v1.96

### DIFF
--- a/compiled_starters/rust/Cargo.toml
+++ b/compiled_starters/rust/Cargo.toml
@@ -3,7 +3,7 @@ name = "codecrafters-git"
 version = "0.1.0"
 authors = ["Codecrafters <hello@codecrafters.io>"]
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.96"
 
 [dependencies]
 anyhow = "1.0.68"                                # error handling

--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -27,7 +27,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.95)` installed locally
+1. Ensure you have `cargo (1.96)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `src/main.rs`. This command compiles your Rust project, so it might be
    slow the first time you run it. Subsequent runs will be fast.

--- a/compiled_starters/rust/codecrafters.yml
+++ b/compiled_starters/rust/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.95
-buildpack: rust-1.95
+# Available versions: rust-1.96
+buildpack: rust-1.96

--- a/dockerfiles/rust-1.96.Dockerfile
+++ b/dockerfiles/rust-1.96.Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM rust:1.96-trixie
+
+# Rebuild the container if these files change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="Cargo.toml,Cargo.lock"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# This runs cargo build
+RUN .codecrafters/compile.sh

--- a/solutions/rust/01-gg4/code/Cargo.toml
+++ b/solutions/rust/01-gg4/code/Cargo.toml
@@ -3,7 +3,7 @@ name = "codecrafters-git"
 version = "0.1.0"
 authors = ["Codecrafters <hello@codecrafters.io>"]
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.96"
 
 [dependencies]
 anyhow = "1.0.68"                                # error handling

--- a/solutions/rust/01-gg4/code/README.md
+++ b/solutions/rust/01-gg4/code/README.md
@@ -27,7 +27,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.95)` installed locally
+1. Ensure you have `cargo (1.96)` installed locally
 1. Run `./your_program.sh` to run your Git implementation, which is implemented
    in `src/main.rs`. This command compiles your Rust project, so it might be
    slow the first time you run it. Subsequent runs will be fast.

--- a/solutions/rust/01-gg4/code/codecrafters.yml
+++ b/solutions/rust/01-gg4/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.95
-buildpack: rust-1.95
+# Available versions: rust-1.96
+buildpack: rust-1.96

--- a/starter_templates/rust/code/Cargo.toml
+++ b/starter_templates/rust/code/Cargo.toml
@@ -3,7 +3,7 @@ name = "codecrafters-git"
 version = "0.1.0"
 authors = ["Codecrafters <hello@codecrafters.io>"]
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.96"
 
 [dependencies]
 anyhow = "1.0.68"                                # error handling

--- a/starter_templates/rust/config.yml
+++ b/starter_templates/rust/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: cargo (1.95)
+  required_executable: cargo (1.96)
   user_editable_file: src/main.rs


### PR DESCRIPTION
CC-2281: Upgrade Rust to v1.96

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-pin and documentation/build infrastructure only; no application logic changes.
> 
> **Overview**
> **Bumps the Rust Git challenge from 1.95 to 1.96** across compiled starters, starter templates, and the sample solution.
> 
> `rust-version` in **Cargo.toml**, **codecrafters.yml** `buildpack: rust-1.96`, and README guidance for local **cargo (1.96)** are updated consistently. **starter_templates/rust/config.yml** now requires **cargo (1.96)**.
> 
> Adds **dockerfiles/rust-1.96.Dockerfile** (based on `rust:1.96-trixie`) for remote builds, mirroring the existing 1.95 image pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 343a2b3fb265a7fce314ca562c469b0aa39e2389. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->